### PR TITLE
Fixed connection issue in nginx configuration

### DIFF
--- a/Utilities/Remotely_Server_Install.sh
+++ b/Utilities/Remotely_Server_Install.sh
@@ -46,7 +46,7 @@ nginxConfig="server {
 		proxy_pass http://localhost:5000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade \$http_upgrade;
-		proxy_set_header Connection \"upgrade\";
+		proxy_set_header Connection \$http_connection;
 		proxy_set_header Host \$host;
 		proxy_cache_bypass \$http_upgrade;
 	}
@@ -54,7 +54,7 @@ nginxConfig="server {
 		proxy_pass http://localhost:5000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade \$http_upgrade;
-		proxy_set_header Connection \"upgrade\";
+		proxy_set_header Connection \$http_connection;
 		proxy_set_header Host \$host;
 		proxy_cache_bypass \$http_upgrade;
 	}
@@ -63,7 +63,7 @@ nginxConfig="server {
 		proxy_pass http://localhost:5000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade \$http_upgrade;
-		proxy_set_header Connection \"upgrade\";
+		proxy_set_header Connection \$http_connection;
 		proxy_set_header Host \$host;
 		proxy_cache_bypass \$http_upgrade;
 	}
@@ -71,7 +71,7 @@ nginxConfig="server {
 		proxy_pass http://localhost:5000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade \$http_upgrade;
-		proxy_set_header Connection \"upgrade\";
+		proxy_set_header Connection \$http_connection;
 		proxy_set_header Host \$host;
 		proxy_cache_bypass \$http_upgrade;
 	}


### PR DESCRIPTION
When using the install script for Linux, the nginx configuration is causing errors when a client is attempting to connect to the server.

Entry in application log: `Microsoft.AspNetCore.SignalR.HubConnectionContext[5] Apr 08 18:04:01 support remotely[7089]: Failed connection handshake.`

This is fixed by setting the Connection header to the `$http_connection` variable.